### PR TITLE
Switch admonitions to markdown-callouts for a simpler syntax

### DIFF
--- a/docs/components/README.md
+++ b/docs/components/README.md
@@ -20,8 +20,7 @@ The very first event that is dispatched is the [ART::Events::Request][Athena::Ro
 
 In some cases the listener may have enough information to return an [ART::Response][Athena::Routing::Response] immediately.  An example of this would be the [ART::Listeners::CORS][Athena::Routing::Listeners::CORS] listener.  If enabled it is able to return a `CORS` preflight response even before routing is invoked.
 
-!!! warning
-    If an [ART::Response][Athena::Routing::Response] is returned at this stage, the flow of the request skips directly to the [response](#5-response-event) event.  Future `Request` event listeners will not be invoked either.
+WARNING: If an [ART::Response][Athena::Routing::Response] is returned at this stage, the flow of the request skips directly to the [response](#5-response-event) event.  Future `Request` event listeners will not be invoked either.
 
 Another use case for this event is populating additional data into the request's attributes; such as the locale or format of the request.
 
@@ -54,8 +53,7 @@ The default algorithm is as follows:
 
 Custom `ArgumentValueResolverInterface`s may be created & registered to extend this functionality.
 
-!!! todo
-    An additional event could possibly be added after the arguments have been resolved, but before invoking the controller action.
+TODO: An additional event could possibly be added after the arguments have been resolved, but before invoking the controller action.
 
 #### Execute the Controller Action
 

--- a/docs/components/config.md
+++ b/docs/components/config.md
@@ -4,8 +4,7 @@ Athena includes the [Athena::Config][] component as a means to configure an Athe
 
 Both configuration and parameters make use of the same high level implementation.  A type is used to "model" the structure and type of each value, whether it's a scalar value like a `String`, or another object.  These types are then added into the base types provided by `Athena::Config`.  This approach provides full compile time type safety both in the structure of the configuration/parameters, but also the type of each value.  It also allows for plenty of flexibility in _how_ each object is constructed.
 
-!!!tip
-    Structs are the preferred type to use, especially for parameters.
+TIP: Structs are the preferred type to use, especially for parameters.
 
 From an organizational standpoint, it is up to the user to determine how they wish to define/organize these configuration/parameter types.  However, the suggested way is to use a central file that should require the individual custom types, for example:
 
@@ -220,8 +219,7 @@ end
 
 To reiterate, the primary benefit of parameters is to centralize and decouple their values from the types that actually use them.  Another benefit is they offer full compile time safety, if for example, the type of `app_url` was mistakenly set to `Int32` or if the parameter's name was typo'd, e.g. `"%app.ap_url%"`; both would result in compile time errors.
 
-!!!note
-    The only valid usecases for accessing parameters directly via `ART.parameters` is within a configuration type, or a type outside of Athena's control/DI framework.
+NOTE: The only valid usecases for accessing parameters directly via `ART.parameters` is within a configuration type, or a type outside of Athena's control/DI framework.
 
 ## Custom Annotations
 

--- a/docs/components/dependency_injection.md
+++ b/docs/components/dependency_injection.md
@@ -45,5 +45,4 @@ ART.run
 # GET / # => "Hello World"
 ```
 
-!!! warning
-    The "type" of the listener has an effect on its behavior!  When a `struct` service is retrieved or injected into a type, it will be a copy of the one in the SC (passed by value). This means that changes made to it in one type, will *NOT* be reflected in other types. A `class` service on the other hand will be a reference to the one in the SC. This allows it to share state between services.
+WARNING: The "type" of the listener has an effect on its behavior!  When a `struct` service is retrieved or injected into a type, it will be a copy of the one in the SC (passed by value). This means that changes made to it in one type, will *NOT* be reflected in other types. A `class` service on the other hand will be a reference to the one in the SC. This allows it to share state between services.

--- a/docs/components/event_dispatcher.md
+++ b/docs/components/event_dispatcher.md
@@ -34,8 +34,7 @@ ART.run
 # GET / # => Hello World (with `FOO => BAR` header)
 ```
 
-!!! tip
-    A single event listener may listen on multiple events.  Instance variables can be used to share state between the events.
+TIP: A single event listener may listen on multiple events.  Instance variables can be used to share state between the events.
 
 ## Custom Events
 

--- a/docs/components/serializer.md
+++ b/docs/components/serializer.md
@@ -2,8 +2,7 @@ The [Serializer][Athena::Serializer] component adds enhanced (de)serialization f
 
 When an [ASR::Serializable][Athena::Serializer::Serializable] is returned from a controller action, that object will be serialized via the serializer component, as opposed to Crystal's standard libraries' `#to_json` method.
 
-!!! info
-    If an object implements _both_ `ASR::Serializable` and `JSON::Serializable`, the serializer component takes priority.
+INFO: If an object implements _both_ `ASR::Serializable` and `JSON::Serializable`, the serializer component takes priority.
 
 The [ARTA::View][Athena::Routing::Annotations::View] annotation can be used to configure serialization related options on a per route basis.
 

--- a/docs/cookbook/listeners.md
+++ b/docs/cookbook/listeners.md
@@ -77,8 +77,7 @@ end
 
 From here, it would be up to the developer to implement a way to authorize the user now that they have been authenticated and are accessible within the application.  One option could be to utilize the [Custom Annotations](../components/config.md#custom-annotations) as a means to "tag" controller actions with specific "levels" of security; then add another `#call` method to the security listener to listen on the [action](../components/README.md#2-action-event) event which exposes the [ART::Action][Athena::Routing::Action] related to the current request from which the annotations could be read off of.
 
-!!! page
-    This example is a modified version of the one used as part of the [JSON API Blog Tutorial](https://dev.to/blacksmoke16/creating-a-json-api-with-athena--granite-510i) blog post.
+PAGE: This example is a modified version of the one used as part of the [JSON API Blog Tutorial](https://dev.to/blacksmoke16/creating-a-json-api-with-athena--granite-510i) blog post.
 
 ## Pagination
 

--- a/docs/cookbook/object_constructors.md
+++ b/docs/cookbook/object_constructors.md
@@ -2,8 +2,7 @@
 
 The [Serializer][Athena::Serializer] component also has the concept of [Object Constructors][Athena::Serializer::ObjectConstructorInterface] that determine how a new object is constructed during deserialization.  A use case could be retrieving the object from the database as part of a `PUT` request in order to apply the deserialized data onto it.  This would allow it to retain the PK, any timestamps, or [ASRA::ReadOnly][ASRA::ReadOnly] values.
 
-!!!note
-    This example uses the `Granite` ORM, but should work with others.
+NOTE: This example uses the `Granite` ORM, but should work with others.
 
 ```crystal
 # Define a custom `ASR::ObjectConstructorInterface` to allow

--- a/docs/cookbook/param_converters.md
+++ b/docs/cookbook/param_converters.md
@@ -145,8 +145,7 @@ The Serializer component also has the concept of [Object Constructors][Athena::S
 
 In a REST API, endpoints usually contain a reference to the `id` of the object in question; e.x. `GET /user/10`.  A useful converter would be able to extract this ID from the path, lookup the related entity, and provide that object directly to the controller action.  This reduces the boilerplate associated with doing a DB lookup within every controller action.  It also makes testing easier as it abstract the logic of _how_ that object is resolved from what should be done to it.
 
-!!!note
-    This example uses the `Granite` ORM, but should work with others.
+NOTE: This example uses the `Granite` ORM, but should work with others.
 
 ```crystal
 # Define an register our param converter as a service.

--- a/docs/getting_started/README.md
+++ b/docs/getting_started/README.md
@@ -99,8 +99,7 @@ ART.run
 
 Restricting an action argument to [HTTP::Request](https://crystal-lang.org/api/HTTP/Request.html) will provide the raw request object.  This can be useful to access data directly off the request object, such consuming the request's body.  This approach is fine for simple or one-off endpoints, however for more complex/common request data processing, it is suggested to create a [Param Converter](advanced_usage.md#param-converters) to handle deserializing directly into an object.
 
-!!!tip
-    See the [cookbook](../cookbook/param_converters.md#request-body) for an example of how to setup a generic request body deserialization/validation converter.
+TIP: See the [cookbook](../cookbook/param_converters.md#request-body) for an example of how to setup a generic request body deserialization/validation converter.
 
 ```crystal
 require "athena"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,6 +64,7 @@ plugins:
 
 markdown_extensions:
   - admonition
+  - callouts
   - pymdownx.highlight
   - pymdownx.magiclink
   - pymdownx.saneheaders

--- a/requirements.in
+++ b/requirements.in
@@ -4,3 +4,4 @@ mkdocstrings-crystal
 mkdocs-gen-files
 mkdocs-literate-nav
 mkdocs-section-index
+markdown-callouts

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,8 +25,11 @@ livereload==2.6.3
     # via mkdocs
 lunr[languages]==0.5.8
     # via mkdocs
+markdown-callouts==0.1.0
+    # via -r requirements.in
 markdown==3.3.4
     # via
+    #   markdown-callouts
     #   mkdocs
     #   mkdocs-autorefs
     #   mkdocs-material


### PR DESCRIPTION
[Hot off the press](https://github.com/oprypin/markdown-callouts/blob/828ed63822fd0b5c1bac417d130bf710f825be7e/markdown_callouts/__init__.py)