### PR TITLE
Introductory Pages Review

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -25,7 +25,7 @@ The Athena website integrates general textual documentation with the API docs of
 This allows for easy linking between the two when applicable.
 It does however leverage some conventions that are helpful to understand when reading the documentation.
 
-The navigation bar towards the top of the screen includes a tab for each component representing that component's API documentation.
+When scrolled to the top of the page, the navigation bar includes a tab for each component representing that component's API documentation.
 The `Manual` tab is the contextual documentation for the framework.
 This includes higher level framework level information, such as its architecture, guides, tutorials, and how each component is integrated if applicable.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 ## Athena
 
 Athena is a collection of robust, independent, and reusable components with the goal of powering a software ecosystem.
-These components may be used on their own to aid in existing projects, or integrated into existing (or new) frameworks.
+These components may be used on their own to aid in existing projects or integrated into existing (or new) frameworks.
 In either case, this enables a feedback loop that ultimately benefits both the project using the component(s), and the ecosystem as a whole.
 The projects themselves get access to quality, well tested code to reduce the maintenance overhead of their application while any issues they do uncover, or additional features that are implemented, benefit not only that project, but every project using that component.
 However, while using them separately is part of their design, they are best used together.
@@ -9,9 +9,9 @@ However, while using them separately is part of their design, they are best used
 ## Athena Framework
 
 Athena Framework integrates each component into a single cohesive, flexible, and modular framework.
-It is designed in such a way that allows for it to accommodate the majority of use cases in a way that can be as simple, or as complex as required.
-Not every component needs to be used or understood to start using the framework.
-Only those which are required for the task at hand. However, of course the components work best when used together within the framework.
+It is designed in such a way that allows for it to accommodate the majority of use cases in a way that can be as simple or as complex as required.
+Not every component needs to be used or understood to start using the framework,
+only those which are required for the task at hand. However, of course the components work best when used together within the framework.
 
 ## Feature Highlights
 

--- a/docs/getting_started/README.md
+++ b/docs/getting_started/README.md
@@ -315,7 +315,7 @@ Non [ATH::Exceptions::HTTPException][] exceptions are represented as a `500 Inte
 
 When an exception is raised, the framework emits the [ATH::Events::Exception][] event to allow an opportunity for it to be handled.
 By default these exceptions will return a `JSON` serialized version of the exception, via [ATH::ErrorRenderer][], that includes the message and code; with the proper response status set.
-If the exception goes unhandled, i.e. no listener sets an ATH::Response on the event, then the request is finished and the exception is re-raised.
+If the exception goes unhandled, i.e. no listener sets an [ATH::Response][] on the event, then the request is finished and the exception is re-raised.
 
 ```crystal
 require "athena"

--- a/docs/getting_started/README.md
+++ b/docs/getting_started/README.md
@@ -1,5 +1,5 @@
 Athena does not have any other dependencies outside of [Crystal](https://crystal-lang.org) and [Shards](https://crystal-lang.org/reference/the_shards_command/index.html).
-It is designed in such a way to be non-intrusive, and not require a strict organizational convention in regards to how a project is setup;
+It is designed in such a way to be non-intrusive and not require a strict organizational convention in regards to how a project is setup;
 this allows it to use a minimal amount of setup boilerplate while not preventing it for more complex projects.
 
 NOTE: Until https://github.com/crystal-lang/crystal/issues/12790 is resolved, you will need to manually install `pcre2` as it is not yet included with a native Crystal install.
@@ -106,10 +106,10 @@ ATH.run
 
 #### Request Parameter
 
-Restricting an action argument to [ATH::Request][] will provide the raw request object. This can be useful to access data directly off the request object, such consuming the request's body.
+Restricting an action argument to [ATH::Request][] will provide the raw request object. This can be useful to access data directly off the request object, such as consuming the request's body.
 This approach is fine for simple or one-off endpoints.
 
-TIP: Checkout [ATHR::RequestBody][] for a better way to handle this.
+TIP: Check out [ATHR::RequestBody][] for a better way to handle this.
 
 ```crystal
 require "athena"
@@ -386,7 +386,7 @@ Invalid num2:  Cannot divide by zero (Athena::Framework::Exceptions::BadRequest)
 
 #### Customization
 
-By default the Athena Framework utilizes the default [Log::Formatter](https://crystal-lang.org/api/Log/Formatter.html) and [Log::Backend](https://crystal-lang.org/api/Log/Backend.html)s Crystal defines. This of course can be customized via interacting with Crystal's [Log](https://crystal-lang.org/api/Log.html) module. It is also possible to control what exceptions, and with what severity, exceptions will be logged by redefining the `log_exception` method within [ATH::Listeners::Error][].
+By default the Athena Framework utilizes the default [Log::Formatter](https://crystal-lang.org/api/Log/Formatter.html) and [Log::Backend](https://crystal-lang.org/api/Log/Backend.html)s Crystal defines. This of course can be customized via interacting with Crystal's [Log](https://crystal-lang.org/api/Log.html) module. It is also possible to control what exceptions, and with what severity, will be logged by redefining the `log_exception` method within [ATH::Listeners::Error][].
 
 ### Middleware
 
@@ -406,11 +406,11 @@ end
 
 Similarly, the framework itself is implemented using the same features available to the users. Thus it is very easy to run specific listeners before/after the built-in ones if so desired.
 
-TIP: Checkout the `debug:event-dispatcher` [command](../architecture/console.md) for an easy way see all the listeners and the order in which they are executed.
+TIP: Check out the `debug:event-dispatcher` [command](../architecture/console.md) for an easy way to see all the listeners and the order in which they are executed.
 
 ### Testing
 
-Many Athena components include a `Spec` module that includes common/helpful testing utilities/types for testing that specific component. The framework itself defines some of its own testing types, mainly to allow for easily integration testing [ATH::Controller][]s via [ATH::Spec::APITestCase] and also provides many helpful `HTTP` related [expectations][ATH::Spec::Expectations::HTTP].
+Many Athena components include a `Spec` module that includes common/helpful testing utilities/types for testing that specific component. The framework itself defines some of its own testing types, mainly to allow for easily integration testing [ATH::Controller][]s via [ATH::Spec::APITestCase][] and also provides many helpful `HTTP` related [expectations][ATH::Spec::Expectations::HTTP].
 
 ```crystal
 require "athena"
@@ -460,4 +460,4 @@ end
 ATH.run prepend_handlers: [ws_handler]
 ```
 
-In the future, a goal is to have an integration with https://mercure.rocks/, which would allow or the majority of WebSocket use cases in a way that better fits into the Athena ecosystem.
+In the future, a goal is to have an integration with https://mercure.rocks/, which would allow for the majority of WebSocket use cases in a way that better fits into the Athena ecosystem.

--- a/docs/getting_started/README.md
+++ b/docs/getting_started/README.md
@@ -313,7 +313,7 @@ Non [ATH::Exceptions::HTTPException][] exceptions are represented as a `500 Inte
 
 When an exception is raised, the framework emits the [ATH::Events::Exception][] event to allow an opportunity for it to be handled.
 By default these exceptions will return a `JSON` serialized version of the exception, via [ATH::ErrorRenderer][], that includes the message and code; with the proper response status set.
-If the exception goes unhandled, i.e. no listener sets an [ATH::Response][]. By default, non [ATH::Response][] on the event, then the request is finished and the exception is re-raised.
+If the exception goes unhandled, i.e. no listener sets an ATH::Response on the event, then the request is finished and the exception is re-raised.
 
 ```crystal
 require "athena"

--- a/docs/why_athena.md
+++ b/docs/why_athena.md
@@ -207,7 +207,7 @@ end
 
 Similarly, the framework itself is implemented using the same features available to the users. Thus it is very easy to run specific listeners before/after the built-in ones if so desired.
 
-TIP: Check out the `debug:event-dispatcher` [command](./architecture/console.md) for an easy way see all the listeners and the order in which they are executed.
+TIP: Check out the `debug:event-dispatcher` [command](./architecture/console.md) for an easy way to see all the listeners and the order in which they are executed.
 
 ### Annotations
 

--- a/docs/why_athena.md
+++ b/docs/why_athena.md
@@ -2,7 +2,7 @@
 
 When creating an application, actually writing the code is often the easiest part. Designing a system that will be readable, maintainable, testable, and extensible on the other hand is a much more challenging task. The features of the Athena Framework encourage creating such software. However it does not do much good without also understanding the _why_ behind the way it is designed the way it is. Let's take a moment to explore how the features mentioned in the introduction can lead to "good" software design.
 
-WARNING: As with anything in the software world, "good" software is subjective. The design decision/suggestions on this page are intended to be educational and provide "best practices" guidelines. They are _NOT_ the only way to use the framework nor are prescriptive. Do whatever makes the most sense for your project.
+WARNING: As with anything in the software world, "good" software is subjective. The design decision/suggestions on this page are intended to be educational and provide "best practices" guidelines. They are _NOT_ the only way to use the framework nor prescriptive. Do whatever makes the most sense for your project.
 
 ### SOLID Principles
 
@@ -49,7 +49,7 @@ end
 
 ##### Services
 
-A sharp eye will notice this type was created with the [ADI::Register][] annotation applied to it. This registers the type as a service, which is essentially just a useful object that could be used by other services. Not all types are services tho, such as the `Article` type. This is because it only stores data within the domain of the application and does not provide any useful functionality on its own. More on this topic in the [dependency injection](./#dependency-injection) section.
+A sharp eye will notice this type was created with the [ADI::Register][] annotation applied to it. This registers the type as a service, which is essentially just a useful object that could be used by other services. Not all types are services though, such as the `Article` type. This is because it only stores data within the domain of the application and does not provide any useful functionality on its own. More on this topic in the [dependency injection](./#dependency-injection) section.
 
 #### Dependency Inversion
 
@@ -95,7 +95,7 @@ def initialize(
 end
 ```
 
-Both of these latter two examples remove the tight coupling between the two services. However there is still one thing that is less than ideal. It should be possible to persist an article in multiple places. Meaning it needs to allow for more than one implementation of `ArticlePersister` that handles different locations, such as one for a database and another for the local filesystem. The best way to handle this would be to create a interface module for this type:
+Both of these latter two examples remove the tight coupling between the two services. However there is still one thing that is less than ideal. It should be possible to persist an article in multiple places. Meaning it needs to allow for more than one implementation of `ArticlePersister` that handles different locations, such as one for a database and another for the local filesystem. The best way to handle this would be to create an interface module for this type:
 
 ```crystal
 module ArticlePersisterInterface
@@ -124,7 +124,7 @@ class ArticlePersister
 end
 ```
 
-While this is a bit of extra boilerplate, it is an incredibly powerful pattern. It enables `MyService` to persist an article to anywhere, depending on what implementation instance it is instantiated with. The same pattern can be extended to make testing the service much easier. A mock implementation of `ArticlePersisterInterface` can be used to assert `MyService` calls it with the proper arguments without testing more than is required.
+While this is a bit of extra boilerplate, it is an incredibly powerful pattern. It enables `MyService` to persist an article to anywhere, depending on what implementation instance it is instantiated with. The same pattern can be extended to make testing the service much easier. A mock implementation of `ArticlePersisterInterface` can be used to assert `MyService` calls with the proper arguments without testing more than is required.
 
 ### Flexibility
 
@@ -187,7 +187,7 @@ class MyCustomErrorRenderer
 end
 ```
 
-Athena Framework will pick this up and use it instead of the built one version without any other required configuration changes. The same concept applies to many different features within the framework that have their own interface/default implementation.
+Athena Framework will pick this up and use it instead of the built in version without any other required configuration changes. The same concept applies to many different features within the framework that have their own interface/default implementation.
 
 #### Middleware
 
@@ -207,7 +207,7 @@ end
 
 Similarly, the framework itself is implemented using the same features available to the users. Thus it is very easy to run specific listeners before/after the built-in ones if so desired.
 
-TIP: Checkout the `debug:event-dispatcher` [command](./architecture/console.md) for an easy way see all the listeners and the order in which they are executed.
+TIP: Check out the `debug:event-dispatcher` [command](./architecture/console.md) for an easy way see all the listeners and the order in which they are executed.
 
 ### Annotations
 
@@ -276,7 +276,7 @@ While the components that make up Athena Framework can be used within a wide ran
 
 ### HTTP REST API
 
-At its core, Athena Framework is a MVC web application framework. It can be used to serve any kind of content, but best lends itself to creating RESTful JSON APIs due to the features the framework as explained in the previous section, as well as due its native JSON support:
+At its core, Athena Framework is a MVC web application framework. It can be used to serve any kind of content, but best lends itself to creating RESTful JSON APIs due to the features explained in the previous section, as well as due its native JSON support:
 
 * Objects returned from the controller are JSON serialized by default
 * Native support for both [ASR::Serializable][] and [JSON::Serializable](https://crystal-lang.org/api/JSON/Serializable.html)

--- a/docs/why_athena.md
+++ b/docs/why_athena.md
@@ -6,7 +6,7 @@ WARNING: As with anything in the software world, "good" software is subjective. 
 
 ### SOLID Principles
 
-The [SOLID](https://en.wikipedia.org/wiki/SOLID) principles are applicable to any Object Oriented Programming (OOP) language. They play a big part in the underlying architecture of the Athena Framework, and the overall ecosystem of Athena itself. There are plenty of resources online to learn more about all of the principles, but this section will focus on that of the _Dependency Inversion_ and _Single Responsibility_ principles and how how an [Inversion of Control (IoC)](https://en.wikipedia.org/wiki/Inversion_of_control) service container orchestrates it all via [dependency injection](https://en.wikipedia.org/wiki/Dependency_injection).
+The [SOLID](https://en.wikipedia.org/wiki/SOLID) principles are applicable to any Object Oriented Programming (OOP) language. They play a big part in the underlying architecture of the Athena Framework, and the overall ecosystem of Athena itself. There are plenty of resources online to learn more about all of the principles, but this section will focus on that of the _Dependency Inversion_ and _Single Responsibility_ principles and how an [Inversion of Control (IoC)](https://en.wikipedia.org/wiki/Inversion_of_control) service container orchestrates it all via [dependency injection](https://en.wikipedia.org/wiki/Dependency_injection).
 
 #### Single Responsibility
 


### PR DESCRIPTION
Reviewed `Introduction`, `Why Athena` and `Getting Started` pages.

## Additional Notes ##
- The Documentation Conventions section of the Introduction can be confusing because the navigation bar it mentions is hidden once you scroll down, which is required to get to the section.

- I don't understand the last two sentences of the third paragraph of the Error Handling section on the Getting Started page. What happens if the exception goes unhandled? It currently reads:
  *"If the exception goes unhandled, i.e. no listener sets an [ATH::Response](https://athenaframework.org/Framework/Response/#Athena::Framework::Response). By default, non [ATH::Response](https://athenaframework.org/Framework/Response/#Athena::Framework::Response) on the event, then the request is finished and the exception is re-raised."*