### PR TITLE
Improve layout on vertical and very wide screens

### DIFF
--- a/docs/css/mkdocstrings.css
+++ b/docs/css/mkdocstrings.css
@@ -8,6 +8,10 @@ div.doc-contents:not(.first) {
 
 /* Additional Customizations */
 
+body {
+    font-size: 1rem;
+}
+
 /* Increased spacing between macro & instance methods. */
 .doc-macro + .doc-macro,
 .doc-instance_method + .doc-instance_method {
@@ -17,10 +21,22 @@ div.doc-contents:not(.first) {
 .md-typeset pre>code::-webkit-scrollbar {
   height: 0.4em;
 }
+/* Slightly more compact headings */
+h1.doc-heading {
+  font-size: 1.3rem;
+}
+h3.doc-heading {
+  font-size: 0.85rem;
+}
 
-/* Make content grid a bit wider */
+/* Make content grid a bit wider (but never wider than the screen) */
 .md-grid {
-  max-width: 75%;
+  max-width: min(80rem, 100vw);
+}
+
+/* Make sure page content doesn't get too wide on big 4k monitors */
+.md-content {
+    max-width: 85ch;
 }
 
 /* Hide prev/next footer buttons */


### PR DESCRIPTION
Small tweaks to layout to make it work better on mobile and ultrawide or 4k screens. This limits the width of the content to 85 characters, which is a little bit more than the usual recommendations but I think it is justified to give a little bit of extra space for long method signatures. I'm not sure why the font-size on body was 0.5rem to start with but I reset it back to 1rem to make styling a little bit easier.

Left is before, right is after (emulating an iPhone 11 screen): 
![image](https://user-images.githubusercontent.com/10672443/232570294-4527723c-f15a-4a73-95d0-265806da8a90.png)
